### PR TITLE
collateral node enforce 2022

### DIFF
--- a/src/main.h
+++ b/src/main.h
@@ -76,7 +76,7 @@ static const int64_t MAX_MONEY = 84000000 * COIN; // 84,000,000 RUPEE Max
 static const int64_t COIN_YEAR_REWARD = 0.1 * COIN; // 10% per year
 
 static const int64_t MAINNET_POSFIX = 250; //Mainnet Proof of Stake update not enabled until block 250
-static const int MN_ENFORCEMENT_ACTIVE_HEIGHT = 80000; // Enforce fortunastake payments after this height - BLOCK 80k
+static const int MN_ENFORCEMENT_ACTIVE_HEIGHT = 2022; // Enforce collateral node payments after this height - BLOCK 2022
 
 inline bool MoneyRange(int64_t nValue) { return (nValue >= 0 && nValue <= MAX_MONEY); }
 


### PR DESCRIPTION
Changed masternode enforcement height to block 2022. Originally was 4500 for D with a 30 sec block time, was changed to 20000 and then 80000 on account of FS not starting up. I plan to get FS (collateral node/masternode) working before 2022 -punny-. Set to 2022 for the current year and is almost the same amount of real time as a 4500 height with 30 block time. Note Rupee Evolution block time should be 60 seconds. First rebrand of fortunastakes to collateral node in //notes.